### PR TITLE
Add endpoint to extract and print text from a URL

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,19 @@
+from fastapi import FastAPI, HTTPException, Query
+from pydantic import HttpUrl
+import requests
+from bs4 import BeautifulSoup
+
+app = FastAPI()
+
+@app.get("/extract-text")
+def extract_text(url: HttpUrl = Query(..., description="The URL to scrape text from")):
+    try:
+        response = requests.get(url)
+        response.raise_for_status()
+    except requests.RequestException as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    soup = BeautifulSoup(response.content, "html.parser")
+    text = soup.get_text(separator="\n", strip=True)
+    print(text)  # Print the scraped text
+    return {"text": text}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 fastapi
 pytest
 uvicorn
+beautifulsoup4
+requests

--- a/test_main.py
+++ b/test_main.py
@@ -1,0 +1,28 @@
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+import requests
+from main import app
+
+client = TestClient(app)
+
+def test_extract_text_success():
+    url = "http://example.com"
+    html_content = "<html><body><p>Hello, World!</p></body></html>"
+    
+    with patch("requests.get") as mock_get:
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.content = html_content
+        
+        response = client.get(f"/extract-text?url={url}")
+        assert response.status_code == 200
+        assert response.json() == {"text": "Hello, World!"}
+
+def test_extract_text_invalid_url():
+    url = "http://invalid-url"
+    
+    with patch("requests.get") as mock_get:
+        mock_get.side_effect = requests.RequestException("Invalid URL")
+        
+        response = client.get(f"/extract-text?url={url}")
+        assert response.status_code == 400
+        assert response.json() == {"detail": "Invalid URL"}


### PR DESCRIPTION
This PR implements an endpoint in the FastAPI application that extracts all text from a given URL and prints the scraped text. It includes the following changes:

1. Added `beautifulsoup4` and `requests` to `requirements.txt`.
2. Created a new endpoint `/extract-text` in `main.py` that accepts a URL as a query parameter, scrapes the text from the URL, and prints it.
3. Added unit tests for the new endpoint in `test_main.py` using `pytest` and `unittest.mock` to mock network requests.

### Test Plan

pytest / cypress