### PR TITLE
Add endpoint to extract text from a URL

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,17 @@
-from fastapi import FastAPI
-
+from fastapi import FastAPI, HTTPException, Query
+from bs4 import BeautifulSoup
+import requests
 
 app = FastAPI()
+
+@app.get("/extract-text")
+def extract_text(url: str = Query(..., description="The URL to scrape text from")):
+    try:
+        response = requests.get(url)
+        response.raise_for_status()
+    except requests.RequestException as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    soup = BeautifulSoup(response.content, "html.parser")
+    text = soup.get_text(separator="\n", strip=True)
+    return {"text": text}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ playwright
 pytest
 pytest-playwright
 uvicorn
+beautifulsoup4
+requests

--- a/test_main.py
+++ b/test_main.py
@@ -1,0 +1,31 @@
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+import requests
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_extract_text_success():
+    url = "http://example.com"
+    html_content = "<html><body><p>Hello, World!</p></body></html>"
+    expected_text = "Hello, World!"
+
+    with patch("requests.get") as mock_get:
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.content = html_content
+
+        response = client.get("/extract-text", params={"url": url})
+        assert response.status_code == 200
+        assert response.json() == {"text": expected_text}
+
+
+def test_extract_text_invalid_url():
+    url = "http://invalid-url"
+
+    with patch("requests.get") as mock_get:
+        mock_get.side_effect = requests.RequestException("Invalid URL")
+
+        response = client.get("/extract-text", params={"url": url})
+        assert response.status_code == 400
+        assert response.json() == {"detail": "Invalid URL"}


### PR DESCRIPTION
This PR adds a new endpoint to the FastAPI application that extracts all text from a given URL and returns it as a JSON response. It also includes the necessary dependencies and unit tests for the new endpoint.

### Test Plan

pytest / cypress