### PR TITLE
Add endpoint to extract text from a URL

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,21 @@
-from fastapi import FastAPI
-
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from bs4 import BeautifulSoup
+import requests
 
 app = FastAPI()
+
+class URLRequest(BaseModel):
+    url: str
+
+@app.post("/extract-text")
+async def extract_text(request: URLRequest):
+    try:
+        response = requests.get(request.url)
+        response.raise_for_status()
+    except requests.RequestException as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    soup = BeautifulSoup(response.content, 'html.parser')
+    text = soup.get_text(separator=' ', strip=True)
+    return {"text": text}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ playwright
 pytest
 pytest-playwright
 uvicorn
+beautifulsoup4
+requests

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,30 @@
+import pytest
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+@pytest.fixture
+def mock_response(monkeypatch):
+    class MockResponse:
+        def __init__(self, content):
+            self.content = content
+            self.status_code = 200
+
+        def raise_for_status(self):
+            pass
+
+    def mock_get(*args, **kwargs):
+        return MockResponse(b"<html><body><p>Hello, World!</p></body></html>")
+
+    monkeypatch.setattr("requests.get", mock_get)
+
+def test_extract_text_success(mock_response):
+    response = client.post("/extract-text", json={"url": "http://example.com"})
+    assert response.status_code == 200
+    assert response.json() == {"text": "Hello, World!"}
+
+def test_extract_text_invalid_url():
+    response = client.post("/extract-text", json={"url": "http://invalid-url"})
+    assert response.status_code == 400
+    assert "Failed to resolve" in response.json()["detail"]


### PR DESCRIPTION
This PR adds an endpoint `/extract-text` to the FastAPI application that extracts all text from a given URL and returns it. It also includes unit tests for the new endpoint.

### Test Plan

pytest / playwright