### PR TITLE
Fix: Handle 406 Client Error for specific URLs

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -21,8 +21,12 @@ def read_root(request: Request):
 
 @app.get("/extract-text")
 def extract_text(url: HttpUrl = Query(..., description="The URL to extract text from")):
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    }
     try:
-        response = requests.get(url)
+        response = requests.get(url, headers=headers)
         response.raise_for_status()
     except requests.RequestException as e:
         raise HTTPException(status_code=400, detail=str(e))

--- a/test_main.py
+++ b/test_main.py
@@ -35,3 +35,23 @@ def test_extract_text_request_exception():
         response = client.get("/extract-text", params={"url": url})
         assert response.status_code == 400
         assert response.json() == {"detail": "Request failed"}
+
+
+def test_extract_text_bermuda():
+    url = "https://thinkingofbermuda.com"
+    html_content = "<html><body><p>Welcome to Bermuda!</p></body></html>"
+    expected_text = "Welcome to Bermuda!"
+
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    }
+
+    with patch("requests.get") as mock_get:
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.content = html_content
+        mock_get.return_value.headers = headers
+
+        response = client.get("/extract-text", params={"url": url})
+        assert response.status_code == 200
+        assert response.json() == {"text": expected_text}

--- a/test_main.py
+++ b/test_main.py
@@ -39,19 +39,7 @@ def test_extract_text_request_exception():
 
 def test_extract_text_bermuda():
     url = "https://thinkingofbermuda.com"
-    html_content = "<html><body><p>Welcome to Bermuda!</p></body></html>"
-    expected_text = "Welcome to Bermuda!"
-
-    headers = {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3",
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
-    }
-
-    with patch("requests.get") as mock_get:
-        mock_get.return_value.status_code = 200
-        mock_get.return_value.content = html_content
-        mock_get.return_value.headers = headers
-
-        response = client.get("/extract-text", params={"url": url})
-        assert response.status_code == 200
-        assert response.json() == {"text": expected_text}
+    
+    response = client.get("/extract-text", params={"url": url})
+    assert response.status_code == 200
+    assert "text" in response.json()


### PR DESCRIPTION
This PR addresses the issue of receiving a 406 Client Error when accessing certain URLs, such as https://thinkingofbermuda.com/. The fix involves adding appropriate headers to the requests to ensure the server can respond correctly.

### Test Plan

pytest / playwright