### PR TITLE
Enhance /extract-text endpoint to extract images along with text

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -20,7 +20,7 @@ def read_root(request: Request):
     return templates.TemplateResponse("index.html", {"request": request})
 
 @app.get("/extract-text")
-def extract_text(url: HttpUrl = Query(..., description="The URL to extract text from")):
+def extract_text(url: HttpUrl = Query(..., description="The URL to extract text and images from")):
     headers = {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3",
         "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
@@ -33,4 +33,20 @@ def extract_text(url: HttpUrl = Query(..., description="The URL to extract text 
 
     soup = BeautifulSoup(response.content, "html.parser")
     text = soup.get_text(separator="\n", strip=True)
-    return {"text": text}
+
+    # Extract images
+    images = []
+    for img in soup.find_all("img"):
+        if img.get("src"):
+            images.append(img["src"])
+    for tag in soup.find_all(style=True):
+        style = tag["style"]
+        if "background-image" in style:
+            start = style.find("url(") + 4
+            end = style.find(")", start)
+            images.append(style[start:end].strip('"').strip("'"))
+    for meta in soup.find_all("meta", property="og:image"):
+        if meta.get("content"):
+            images.append(meta["content"])
+
+    return {"text": text, "images": images}

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,15 +3,15 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Text Extractor</title>
+    <title>Text and Image Extractor</title>
     <link rel="stylesheet" href="/static/styles.css">
 </head>
 <body>
-    <h1>Text Extractor</h1>
+    <h1>Text and Image Extractor</h1>
     <form id="url-form">
         <label for="url-input">Enter URL:</label>
         <input type="text" id="url-input" name="url" required>
-        <button type="submit">Extract Text</button>
+        <button type="submit">Extract</button>
     </form>
     <div id="result"></div>
     <script src="/static/scripts.js"></script>

--- a/templates/static/scripts.js
+++ b/templates/static/scripts.js
@@ -9,6 +9,19 @@ document.getElementById('url-form').addEventListener('submit', async function(ev
         const data = await response.json();
         if (response.ok) {
             resultDiv.textContent = data.text;
+
+            // Create a div to hold the images
+            const imagesDiv = document.createElement('div');
+            data.images.forEach(src => {
+                const img = document.createElement('img');
+                img.src = src;
+                img.style.maxWidth = '200px';
+                img.style.margin = '10px';
+                imagesDiv.appendChild(img);
+            });
+
+            // Append the images div to the result div
+            resultDiv.appendChild(imagesDiv);
         } else {
             resultDiv.textContent = `Error: ${data.detail}`;
         }

--- a/test_main.py
+++ b/test_main.py
@@ -18,7 +18,7 @@ def test_extract_text_success():
 
         response = client.get("/extract-text", params={"url": url})
         assert response.status_code == 200
-        assert response.json() == {"text": expected_text}
+        assert response.json() == {"text": expected_text, "images": []}
 
 
 def test_extract_text_invalid_url():
@@ -43,3 +43,32 @@ def test_extract_text_bermuda():
     response = client.get("/extract-text", params={"url": url})
     assert response.status_code == 200
     assert "text" in response.json()
+    assert "images" in response.json()
+
+
+def test_extract_text_and_images_success():
+    url = "http://example.com"
+    html_content = """
+    <html>
+        <body>
+            <p>Hello, World!</p>
+            <img src="http://example.com/image1.jpg" />
+            <div style="background-image: url('http://example.com/image2.jpg');"></div>
+            <meta property="og:image" content="http://example.com/image3.jpg" />
+        </body>
+    </html>
+    """
+    expected_text = "Hello, World!"
+    expected_images = [
+        "http://example.com/image1.jpg",
+        "http://example.com/image2.jpg",
+        "http://example.com/image3.jpg"
+    ]
+
+    with patch("requests.get") as mock_get:
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.content = html_content
+
+        response = client.get("/extract-text", params={"url": url})
+        assert response.status_code == 200
+        assert response.json() == {"text": expected_text, "images": expected_images}

--- a/test_ui.py
+++ b/test_ui.py
@@ -11,9 +11,17 @@ def browser():
 
 def test_ui(browser):
     page = browser.new_page()
+
+    # Mock the backend response for /extract-text
+    page.route("**/extract-text?url=http%3A%2F%2Fexample.com", lambda route: route.fulfill(
+        status=200,
+        content_type="application/json",
+        body='{"text": "Example Domain", "images": ["http://example.com/image1.jpg", "http://example.com/image2.jpg"]}'
+    ))
+
     page.goto("http://localhost:8080/")
 
-    # Test form submission
+    # Test form submission for text extraction
     page.fill("input[name='url']", "http://example.com")
     page.click("button[type='submit']")
 
@@ -24,3 +32,9 @@ def test_ui(browser):
     # Check the result
     result_text = page.text_content("#result")
     assert "Example Domain" in result_text
+
+    # Check the images
+    images = page.query_selector_all("#result img")
+    assert len(images) > 0
+    for img in images:
+        assert img.get_attribute("src").startswith("http://example.com")


### PR DESCRIPTION
This PR enhances the /extract-text endpoint to extract images from various HTML tags along with text. It also updates the frontend to display the extracted images.

### Test Plan

pytest / playwright