### PR TITLE
Enhance /extract-text endpoint to extract images along with text

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -34,7 +34,12 @@ def extract_text(url: HttpUrl = Query(..., description="The URL to extract text 
     soup = BeautifulSoup(response.content, "html.parser")
     text = soup.get_text(separator="\n", strip=True)
 
-    # Extract images from various tags
+    # Extract images using the utility method
+    images = extract_images(soup)
+
+    return {"text": text, "images": images}
+
+def extract_images(soup):
     images = []
     for img in soup.find_all(["img", "meta", "link", "source"]):
         if img.name == "img" and img.get("src"):
@@ -45,5 +50,4 @@ def extract_text(url: HttpUrl = Query(..., description="The URL to extract text 
             images.append(img["href"])
         elif img.name == "source" and img.get("srcset"):
             images.append(img["srcset"].split()[0])  # Take the first URL in srcset
-
-    return {"text": text, "images": images}
+    return images

--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,7 @@ from pydantic import HttpUrl
 import requests
 from bs4 import BeautifulSoup
 import os
+from app.scraping import extract_images
 
 app = FastAPI()
 
@@ -38,16 +39,3 @@ def extract_text(url: HttpUrl = Query(..., description="The URL to extract text 
     images = extract_images(soup)
 
     return {"text": text, "images": images}
-
-def extract_images(soup):
-    images = []
-    for img in soup.find_all(["img", "meta", "link", "source"]):
-        if img.name == "img" and img.get("src"):
-            images.append(img["src"])
-        elif img.name == "meta" and img.get("content") and "image" in img.get("property", ""):
-            images.append(img["content"])
-        elif img.name == "link" and img.get("href") and "image" in img.get("type", ""):
-            images.append(img["href"])
-        elif img.name == "source" and img.get("srcset"):
-            images.append(img["srcset"].split()[0])  # Take the first URL in srcset
-    return images

--- a/app/scraping.py
+++ b/app/scraping.py
@@ -1,0 +1,14 @@
+from bs4 import BeautifulSoup
+
+def extract_images(soup: BeautifulSoup) -> list:
+    images = []
+    for img in soup.find_all(["img", "meta", "link", "source"]):
+        if img.name == "img" and img.get("src"):
+            images.append(img["src"])
+        elif img.name == "meta" and img.get("content") and "image" in img.get("property", ""):
+            images.append(img["content"])
+        elif img.name == "link" and img.get("href") and "image" in img.get("type", ""):
+            images.append(img["href"])
+        elif img.name == "source" and img.get("srcset"):
+            images.append(img["srcset"].split()[0])  # Take the first URL in srcset
+    return images

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,17 +3,20 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Text Extractor</title>
+    <title>Text and Image Extractor</title>
     <link rel="stylesheet" href="/static/styles.css">
 </head>
 <body>
-    <h1>Text Extractor</h1>
+    <h1>Text and Image Extractor</h1>
     <form id="url-form">
         <label for="url-input">Enter URL:</label>
         <input type="text" id="url-input" name="url" required>
-        <button type="submit">Extract Text</button>
+        <button type="submit">Extract</button>
     </form>
-    <div id="result"></div>
+    <div id="result">
+        <div id="text-result"></div>
+        <div id="image-result"></div>
+    </div>
     <script src="/static/scripts.js"></script>
 </body>
 </html>

--- a/templates/static/scripts.js
+++ b/templates/static/scripts.js
@@ -1,18 +1,32 @@
 document.getElementById('url-form').addEventListener('submit', async function(event) {
     event.preventDefault();
     const urlInput = document.getElementById('url-input').value;
+    const textResultDiv = document.getElementById('text-result');
+    const imageResultDiv = document.getElementById('image-result');
     const resultDiv = document.getElementById('result');
-    resultDiv.textContent = 'Loading...';
+    
+    textResultDiv.textContent = 'Loading...';
+    imageResultDiv.innerHTML = ''; // Clear previous images
 
     try {
         const response = await fetch(`/extract-text?url=${encodeURIComponent(urlInput)}`);
         const data = await response.json();
         if (response.ok) {
-            resultDiv.textContent = data.text;
+            textResultDiv.textContent = data.text;
+
+            // Display images
+            data.images.forEach(src => {
+                const img = document.createElement('img');
+                img.src = src;
+                img.alt = 'Extracted image';
+                img.style.maxWidth = '100%';
+                img.style.margin = '10px 0';
+                imageResultDiv.appendChild(img);
+            });
         } else {
-            resultDiv.textContent = `Error: ${data.detail}`;
+            textResultDiv.textContent = `Error: ${data.detail}`;
         }
     } catch (error) {
-        resultDiv.textContent = `Error: ${error.message}`;
+        textResultDiv.textContent = `Error: ${error.message}`;
     }
 });

--- a/test_main.py
+++ b/test_main.py
@@ -3,7 +3,8 @@ from fastapi.testclient import TestClient
 from unittest.mock import patch
 import requests
 from bs4 import BeautifulSoup
-from app.main import app, extract_images
+from app.main import app
+from app.scraping import extract_images
 
 client = TestClient(app)
 

--- a/test_main.py
+++ b/test_main.py
@@ -9,8 +9,17 @@ client = TestClient(app)
 
 def test_extract_text_success():
     url = "http://example.com"
-    html_content = "<html><body><p>Hello, World!</p></body></html>"
+    html_content = """
+    <html>
+        <body>
+            <p>Hello, World!</p>
+            <img src="http://example.com/image1.jpg" />
+            <img src="http://example.com/image2.jpg" />
+        </body>
+    </html>
+    """
     expected_text = "Hello, World!"
+    expected_images = ["http://example.com/image1.jpg", "http://example.com/image2.jpg"]
 
     with patch("requests.get") as mock_get:
         mock_get.return_value.status_code = 200
@@ -18,7 +27,7 @@ def test_extract_text_success():
 
         response = client.get("/extract-text", params={"url": url})
         assert response.status_code == 200
-        assert response.json() == {"text": expected_text}
+        assert response.json() == {"text": expected_text, "images": expected_images}
 
 
 def test_extract_text_invalid_url():
@@ -43,3 +52,4 @@ def test_extract_text_bermuda():
     response = client.get("/extract-text", params={"url": url})
     assert response.status_code == 200
     assert "text" in response.json()
+    assert "images" in response.json()

--- a/test_main.py
+++ b/test_main.py
@@ -2,7 +2,8 @@ import pytest
 from fastapi.testclient import TestClient
 from unittest.mock import patch
 import requests
-from app.main import app
+from bs4 import BeautifulSoup
+from app.main import app, extract_images
 
 client = TestClient(app)
 
@@ -53,3 +54,24 @@ def test_extract_text_bermuda():
     assert response.status_code == 200
     assert "text" in response.json()
     assert "images" in response.json()
+
+
+def test_extract_images():
+    html_content = """
+    <html>
+        <body>
+            <img src="http://example.com/image1.jpg" />
+            <meta property="og:image" content="http://example.com/image2.jpg" />
+            <link rel="image_src" href="http://example.com/image3.jpg" type="image/jpeg" />
+            <source srcset="http://example.com/image4.jpg 1x, http://example.com/image5.jpg 2x" />
+        </body>
+    </html>
+    """
+    soup = BeautifulSoup(html_content, "html.parser")
+    expected_images = [
+        "http://example.com/image1.jpg",
+        "http://example.com/image2.jpg",
+        "http://example.com/image3.jpg",
+        "http://example.com/image4.jpg"
+    ]
+    assert extract_images(soup) == expected_images


### PR DESCRIPTION
This PR enhances the `/extract-text` endpoint to extract images along with text from the provided URL. It updates the backend, frontend, and tests to support this new functionality.

### Test Plan

pytest / playwright