### PR TITLE
Update OpenAI API to use client-based approach

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -7,15 +7,15 @@ import requests
 from bs4 import BeautifulSoup
 import os
 from app.scraping import extract_images
-from app.openai_utils import generate_headline  # Import the function here
+from app.openai_utils import generate_headline
 from dotenv import load_dotenv
-import openai
+from openai import OpenAI
 
 # Load environment variables
 load_dotenv()
 
 # Initialize OpenAI API key
-openai.api_key = os.getenv("OPENAI_API_KEY")
+openai_api_key = os.getenv("OPENAI_API_KEY")
 
 app = FastAPI()
 
@@ -48,7 +48,10 @@ def extract_text(url: HttpUrl = Query(..., description="The URL to extract text 
     # Extract images using the utility method
     images = extract_images(soup)
 
+    # Initialize OpenAI client
+    client = OpenAI(api_key=openai_api_key)
+
     # Generate headlines for each image
-    headlines = [generate_headline(text, image) for image in images]
+    headlines = [generate_headline(client, text, image) for image in images]
 
     return {"text": text, "images": images, "headlines": headlines}

--- a/app/openai_utils.py
+++ b/app/openai_utils.py
@@ -1,8 +1,14 @@
-import openai
+from openai import OpenAI
+import os
+
+def get_openai_client():
+    return OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
 
 def generate_headline(text: str, image_url: str) -> str:
+    client = get_openai_client()
     prompt = f"Generate an ad headline for the following image URL based on the website text:\n\nWebsite Text:\n{text}\n\nImage URL: {image_url}\n\nAd Headline:"
-    response = openai.ChatCompletion.create(
+    response = client.chat.completions.create(
         model="gpt-3.5-turbo",
         messages=[
             {"role": "system", "content": "You are a helpful assistant."},
@@ -11,4 +17,3 @@ def generate_headline(text: str, image_url: str) -> str:
         max_tokens=50
     )
     return response.choices[0].message['content'].strip()
-

--- a/app/openai_utils.py
+++ b/app/openai_utils.py
@@ -1,12 +1,8 @@
 from openai import OpenAI
 import os
 
-def get_openai_client():
-    return OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
-
-def generate_headline(text: str, image_url: str) -> str:
-    client = get_openai_client()
+def generate_headline(client, text: str, image_url: str) -> str:
     prompt = f"Generate an ad headline for the following image URL based on the website text:\n\nWebsite Text:\n{text}\n\nImage URL: {image_url}\n\nAd Headline:"
     response = client.chat.completions.create(
         model="gpt-3.5-turbo",

--- a/test_main.py
+++ b/test_main.py
@@ -1,37 +1,14 @@
 import pytest
 from fastapi.testclient import TestClient
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 import requests
 from bs4 import BeautifulSoup
 from app.main import app
 from app.openai_utils import generate_headline, get_openai_client
 from app.scraping import extract_images
-import os
+from test_utils import set_openai_api_key, mock_openai_client
 
 client = TestClient(app)
-
-
-def mock_openai_chat_completion_create(*args, **kwargs):
-    class MockResponse:
-        def __init__(self):
-            self.choices = [self]
-
-        @property
-        def message(self):
-            return {"content": "Mocked Ad Headline"}
-
-    return MockResponse()
-
-@pytest.fixture(autouse=True)
-def set_openai_api_key():
-    with patch.dict(os.environ, {"OPENAI_API_KEY": "test"}):
-        yield
-
-
-def mock_openai_client():
-    mock_client = MagicMock()
-    mock_client.chat.completions.create.side_effect = mock_openai_chat_completion_create
-    return mock_client
 
 
 def test_generate_headline():

--- a/test_main.py
+++ b/test_main.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import requests
 from bs4 import BeautifulSoup
 from app.main import app
-from app.openai_utils import generate_headline, get_openai_client
+from app.openai_utils import generate_headline
 from app.scraping import extract_images
 from test_utils import set_openai_api_key, mock_openai_client
 
@@ -14,9 +14,9 @@ client = TestClient(app)
 def test_generate_headline():
     text = "This is a sample website text."
     image_url = "http://example.com/image.jpg"
-    with patch("app.openai_utils.get_openai_client", return_value=mock_openai_client()):
-        headline = generate_headline(text, image_url)
-        assert headline == "Mocked Ad Headline"
+    mock_client = mock_openai_client()
+    headline = generate_headline(mock_client, text, image_url)
+    assert headline == "Mocked Ad Headline"
 
 
 def test_extract_text_success():
@@ -34,7 +34,7 @@ def test_extract_text_success():
     expected_images = ["http://example.com/image1.jpg", "http://example.com/image2.jpg"]
     expected_headlines = ["Mocked Ad Headline", "Mocked Ad Headline"]
 
-    with patch("requests.get") as mock_get, patch("app.openai_utils.get_openai_client", return_value=mock_openai_client()):
+    with patch("requests.get") as mock_get, patch("app.main.OpenAI", return_value=mock_openai_client()):
         mock_get.return_value.status_code = 200
         mock_get.return_value.content = html_content
 
@@ -62,7 +62,7 @@ def test_extract_text_request_exception():
 def test_extract_text_bermuda():
     url = "https://thinkingofbermuda.com"
     
-    with patch("app.openai_utils.get_openai_client", return_value=mock_openai_client()):
+    with patch("app.main.OpenAI", return_value=mock_openai_client()):
         response = client.get("/extract-text", params={"url": url})
         assert response.status_code == 200
         assert "text" in response.json()

--- a/test_utils.py
+++ b/test_utils.py
@@ -1,0 +1,27 @@
+import pytest
+from unittest.mock import patch, MagicMock
+import os
+
+
+def mock_openai_chat_completion_create(*args, **kwargs):
+    class MockResponse:
+        def __init__(self):
+            self.choices = [self]
+
+        @property
+        def message(self):
+            return {"content": "Mocked Ad Headline"}
+
+    return MockResponse()
+
+
+@pytest.fixture(autouse=True)
+def set_openai_api_key():
+    with patch.dict(os.environ, {"OPENAI_API_KEY": "test"}):
+        yield
+
+
+def mock_openai_client():
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.side_effect = mock_openai_chat_completion_create
+    return mock_client


### PR DESCRIPTION
This PR updates the OpenAI API usage in the FastAPI application to use the new client-based approach. The changes include updating the `generate_headline` function and modifying the unit tests to mock the new client-based approach.

### Test Plan

pytest / playwright