### PR TITLE
Fix API issue in generate_headline function

### DIFF
--- a/app/openai_utils.py
+++ b/app/openai_utils.py
@@ -12,4 +12,4 @@ def generate_headline(client, text: str, image_url: str) -> str:
         ],
         max_tokens=50
     )
-    return response.choices[0].message['content'].strip()
+    return response.choices[0].message.content.strip()  # Corrected this line

--- a/app/openai_utils.py
+++ b/app/openai_utils.py
@@ -12,4 +12,4 @@ def generate_headline(client, text: str, image_url: str) -> str:
         ],
         max_tokens=50
     )
-    return response.choices[0].message.content.strip()  # Corrected this line
+    return response.choices[0].message.content.strip()

--- a/test_utils.py
+++ b/test_utils.py
@@ -10,7 +10,10 @@ def mock_openai_chat_completion_create(*args, **kwargs):
 
         @property
         def message(self):
-            return {"content": "Mocked Ad Headline"}
+            class Message:
+                def __init__(self):
+                    self.content = "Mocked Ad Headline"
+            return Message()
 
     return MockResponse()
 


### PR DESCRIPTION
This PR fixes the issue in the generate_headline function where the response from the OpenAI API was being accessed incorrectly. The response structure has been corrected, and the corresponding unit tests have been updated.

### Test Plan

pytest / playwright