### PR TITLE
Update headline prompt to limit to 5 words

### DIFF
--- a/app/openai_utils.py
+++ b/app/openai_utils.py
@@ -3,7 +3,13 @@ import os
 
 
 def generate_headline(client, text: str, image_url: str) -> str:
-    prompt = f"Generate an ad headline for the following image URL based on the website text:\n\nWebsite Text:\n{text}\n\nImage URL: {image_url}\n\nAd Headline:"
+    prompt = (
+        f"Generate an ad headline for the following image URL based on the website text. "
+        f"The headline should be no more than 5 words long:\n\n"
+        f"Website Text:\n{text}\n\n"
+        f"Image URL: {image_url}\n\n"
+        f"Ad Headline:"
+    )
     response = client.chat.completions.create(
         model="gpt-3.5-turbo",
         messages=[

--- a/test_main.py
+++ b/test_main.py
@@ -17,6 +17,7 @@ def test_generate_headline():
     mock_client = mock_openai_client()
     headline = generate_headline(mock_client, text, image_url)
     assert headline == "Mocked Ad Headline"
+    assert len(headline.split()) <= 5  # Ensure the headline is no more than 5 words
 
 
 def test_extract_text_success():
@@ -41,6 +42,8 @@ def test_extract_text_success():
         response = client.get("/extract-text", params={"url": url})
         assert response.status_code == 200
         assert response.json() == {"text": expected_text, "images": expected_images, "headlines": expected_headlines}
+        for headline in response.json()["headlines"]:
+            assert len(headline.split()) <= 5  # Ensure each headline is no more than 5 words
 
 
 def test_extract_text_invalid_url():
@@ -68,6 +71,8 @@ def test_extract_text_bermuda():
         assert "text" in response.json()
         assert "images" in response.json()
         assert "headlines" in response.json()
+        for headline in response.json()["headlines"]:
+            assert len(headline.split()) <= 5  # Ensure each headline is no more than 5 words
 
 
 def test_extract_images():

--- a/test_ui.py
+++ b/test_ui.py
@@ -8,6 +8,7 @@ def browser():
         yield browser
         browser.close()
 
+
 def test_ui(browser):
     page = browser.new_page()
 
@@ -15,7 +16,7 @@ def test_ui(browser):
     page.route("**/extract-text?url=http%3A%2F%2Fexample.com", lambda route: route.fulfill(
         status=200,
         content_type="application/json",
-        body='{"text": "Example Domain", "images": ["http://example.com/image1.jpg", "http://example.com/image2.jpg"], "headlines": ["Mocked Ad Headline 1", "Mocked Ad Headline 2"]}'
+        body='{"text": "Example Domain", "images": ["http://example.com/image1.jpg", "http://example.com/image2.jpg"], "headlines": ["Mocked Ad Headline", "Another Mocked Headline"]}'
     ))
 
     page.goto("http://localhost:8080/")
@@ -44,7 +45,8 @@ def test_ui(browser):
 
     # Verify the headlines
     headlines = page.query_selector_all("#image-result p")
-    expected_headlines = ["Mocked Ad Headline 1", "Mocked Ad Headline 2"]
+    expected_headlines = ["Mocked Ad Headline", "Another Mocked Headline"]
     for headline, expected_text in zip(headlines, expected_headlines):
         text = headline.text_content()
         assert text == expected_text
+        assert len(text.split()) <= 5  # Ensure each headline is no more than 5 words


### PR DESCRIPTION
This PR updates the headline generation prompt to ensure that the generated headline is no more than 5 words long. It also includes updates to the unit tests and E2E tests to reflect this new constraint.

### Test Plan

pytest / playwright