### PR TITLE
Limit number of images to scrape using N_IMAGES environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 OPENAI_API_KEY=your_openai_api_key_here
+N_IMAGES=5

--- a/app/scraping.py
+++ b/app/scraping.py
@@ -4,7 +4,7 @@ import os
 
 def extract_images(soup: BeautifulSoup) -> list:
     images = []
-    n_images = int(os.getenv("N_IMAGES", 10))  # Default to 10 if not set
+    n_images = int(os.getenv("N_IMAGES", 4))  # Default to 4 if not set
     for img in soup.find_all(["img", "meta", "link", "source"]):
         if img.name == "img" and img.get("src"):
             images.append(img["src"])

--- a/app/scraping.py
+++ b/app/scraping.py
@@ -1,7 +1,10 @@
 from bs4 import BeautifulSoup
+import os
+
 
 def extract_images(soup: BeautifulSoup) -> list:
     images = []
+    n_images = int(os.getenv("N_IMAGES", 10))  # Default to 10 if not set
     for img in soup.find_all(["img", "meta", "link", "source"]):
         if img.name == "img" and img.get("src"):
             images.append(img["src"])
@@ -11,4 +14,6 @@ def extract_images(soup: BeautifulSoup) -> list:
             images.append(img["href"])
         elif img.name == "source" and img.get("srcset"):
             images.append(img["srcset"].split()[0])  # Take the first URL in srcset
+        if len(images) >= n_images:
+            break
     return images

--- a/test_main.py
+++ b/test_main.py
@@ -2,6 +2,7 @@ import pytest
 from fastapi.testclient import TestClient
 from unittest.mock import patch
 import requests
+import os
 from bs4 import BeautifulSoup
 from app.main import app
 from app.openai_utils import generate_headline
@@ -94,3 +95,23 @@ def test_extract_images():
         "http://example.com/image4.jpg"
     ]
     assert extract_images(soup) == expected_images
+
+
+def test_extract_images_with_limit():
+    html_content = """
+    <html>
+        <body>
+            <img src="http://example.com/image1.jpg" />
+            <img src="http://example.com/image2.jpg" />
+            <img src="http://example.com/image3.jpg" />
+            <img src="http://example.com/image4.jpg" />
+        </body>
+    </html>
+    """
+    soup = BeautifulSoup(html_content, "html.parser")
+    with patch.dict(os.environ, {"N_IMAGES": "2"}):
+        expected_images = [
+            "http://example.com/image1.jpg",
+            "http://example.com/image2.jpg"
+        ]
+        assert extract_images(soup) == expected_images

--- a/test_ui.py
+++ b/test_ui.py
@@ -50,3 +50,46 @@ def test_ui(browser):
         text = headline.text_content()
         assert text == expected_text
         assert len(text.split()) <= 5  # Ensure each headline is no more than 5 words
+
+
+def test_ui_with_limited_images(browser):
+    page = browser.new_page()
+
+    # Mock the fetch request to /extract-text
+    page.route("**/extract-text?url=http%3A%2F%2Fexample.com", lambda route: route.fulfill(
+        status=200,
+        content_type="application/json",
+        body='{"text": "Example Domain", "images": ["http://example.com/image1.jpg"], "headlines": ["Mocked Ad Headline"]}'
+    ))
+
+    page.goto("http://localhost:8080/")
+
+    # Test form submission
+    page.fill("input[name='url']", "http://example.com")
+    page.click("button[type='submit']")
+
+    # Wait for the result to be updated
+    page.wait_for_selector("#result", state="visible")
+    page.wait_for_function("document.getElementById('result').textContent !== 'Loading...'")
+
+    # Check the result
+    result_text = page.text_content("#text-result")
+    assert "Example Domain" in result_text
+
+    # Check for images
+    images = page.query_selector_all("#image-result img")
+    assert len(images) == 1
+
+    # Verify the image sources
+    expected_images = ["http://example.com/image1.jpg"]
+    for img, expected_src in zip(images, expected_images):
+        src = img.get_attribute("src")
+        assert src == expected_src
+
+    # Verify the headlines
+    headlines = page.query_selector_all("#image-result p")
+    expected_headlines = ["Mocked Ad Headline"]
+    for headline, expected_text in zip(headlines, expected_headlines):
+        text = headline.text_content()
+        assert text == expected_text
+        assert len(text.split()) <= 5  # Ensure each headline is no more than 5 words


### PR DESCRIPTION
This PR introduces a new environment variable `N_IMAGES` to limit the number of images scraped from a webpage. The changes include updates to the scraping logic, unit tests, and UI tests.

### Test Plan

pytest / playwright