### PR TITLE
Remove Scraped Text from UI

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -54,4 +54,4 @@ def extract_text(url: HttpUrl = Query(..., description="The URL to extract text 
     # Generate headlines for each image
     headlines = [generate_headline(client, text, image) for image in images]
 
-    return {"text": text, "images": images, "headlines": headlines}
+    return {"images": images, "headlines": headlines}

--- a/templates/static/scripts.js
+++ b/templates/static/scripts.js
@@ -1,18 +1,14 @@
 document.getElementById('url-form').addEventListener('submit', async function(event) {
     event.preventDefault();
     const urlInput = document.getElementById('url-input').value;
-    const textResultDiv = document.getElementById('text-result');
     const imageResultDiv = document.getElementById('image-result');
     
-    textResultDiv.textContent = 'Loading...';
     imageResultDiv.innerHTML = ''; // Clear previous images
 
     try {
         const response = await fetch(`/extract-text?url=${encodeURIComponent(urlInput)}`);
         const data = await response.json();
         if (response.ok) {
-            textResultDiv.textContent = data.text;
-
             // Display images and headlines
             data.images.forEach((src, index) => {
                 const container = document.createElement('div');
@@ -47,9 +43,9 @@ document.getElementById('url-form').addEventListener('submit', async function(ev
                 }
             });
         } else {
-            textResultDiv.textContent = `Error: ${data.detail}`;
+            imageResultDiv.textContent = `Error: ${data.detail}`;
         }
     } catch (error) {
-        textResultDiv.textContent = `Error: ${error.message}`;
+        imageResultDiv.textContent = `Error: ${error.message}`;
     }
 });

--- a/test_main.py
+++ b/test_main.py
@@ -32,7 +32,6 @@ def test_extract_text_success():
         </body>
     </html>
     """
-    expected_text = "Hello, World!"
     expected_images = ["http://example.com/image1.jpg", "http://example.com/image2.jpg"]
     expected_headlines = ["Mocked Ad Headline", "Mocked Ad Headline"]
 
@@ -42,7 +41,7 @@ def test_extract_text_success():
 
         response = client.get("/extract-text", params={"url": url})
         assert response.status_code == 200
-        assert response.json() == {"text": expected_text, "images": expected_images, "headlines": expected_headlines}
+        assert response.json() == {"images": expected_images, "headlines": expected_headlines}
         for headline in response.json()["headlines"]:
             assert len(headline.split()) <= 5  # Ensure each headline is no more than 5 words
 
@@ -69,7 +68,6 @@ def test_extract_text_bermuda():
     with patch("app.main.OpenAI", return_value=mock_openai_client()):
         response = client.get("/extract-text", params={"url": url})
         assert response.status_code == 200
-        assert "text" in response.json()
         assert "images" in response.json()
         assert "headlines" in response.json()
         for headline in response.json()["headlines"]:

--- a/test_ui.py
+++ b/test_ui.py
@@ -16,7 +16,7 @@ def test_ui(browser):
     page.route("**/extract-text?url=http%3A%2F%2Fexample.com", lambda route: route.fulfill(
         status=200,
         content_type="application/json",
-        body='{"text": "Example Domain", "images": ["http://example.com/image1.jpg", "http://example.com/image2.jpg"], "headlines": ["Mocked Ad Headline", "Another Mocked Headline"]}'
+        body='{"images": ["http://example.com/image1.jpg", "http://example.com/image2.jpg"], "headlines": ["Mocked Ad Headline", "Another Mocked Headline"]}'
     ))
 
     page.goto("http://localhost:8080/")
@@ -28,10 +28,6 @@ def test_ui(browser):
     # Wait for the result to be updated
     page.wait_for_selector("#result", state="visible")
     page.wait_for_function("document.getElementById('result').textContent !== 'Loading...'")
-
-    # Check the result
-    result_text = page.text_content("#text-result")
-    assert "Example Domain" in result_text
 
     # Check for images
     images = page.query_selector_all("#image-result .image-container")
@@ -68,7 +64,7 @@ def test_ui_with_limited_images(browser):
     page.route("**/extract-text?url=http%3A%2F%2Fexample.com", lambda route: route.fulfill(
         status=200,
         content_type="application/json",
-        body='{"text": "Example Domain", "images": ["http://example.com/image1.jpg"], "headlines": ["Mocked Ad Headline"]}'
+        body='{"images": ["http://example.com/image1.jpg"], "headlines": ["Mocked Ad Headline"]}'
     ))
 
     page.goto("http://localhost:8080/")
@@ -80,10 +76,6 @@ def test_ui_with_limited_images(browser):
     # Wait for the result to be updated
     page.wait_for_selector("#result", state="visible")
     page.wait_for_function("document.getElementById('result').textContent !== 'Loading...'")
-
-    # Check the result
-    result_text = page.text_content("#text-result")
-    assert "Example Domain" in result_text
 
     # Check for images
     images = page.query_selector_all("#image-result .image-container")
@@ -111,4 +103,3 @@ def test_ui_with_limited_images(browser):
         page.mouse.up()
         new_box = headline.bounding_box()
         assert new_box['x'] != box['x'] or new_box['y'] != box['y']  # Ensure the position has changed
-


### PR DESCRIPTION
This PR addresses ticket TES-16 by removing the scraped text from the UI. The `/extract-text` endpoint now excludes the text from its response, and the frontend has been updated to handle the new response format, ensuring that only images and headlines are displayed.

### Test Plan

pytest / playwright