### PR TITLE
TES-17: Ensure Text Can't Leave Image Frame

### DIFF
--- a/templates/static/scripts.js
+++ b/templates/static/scripts.js
@@ -30,11 +30,35 @@ document.getElementById('url-form').addEventListener('submit', async function(ev
 
             // Initialize interact.js for drag-and-drop
             interact('.draggable').draggable({
+                modifiers: [
+                    interact.modifiers.restrict({
+                        restriction: 'parent',
+                        endOnly: true,
+                        elementRect: { top: 0, left: 0, bottom: 1, right: 1 }
+                    })
+                ],
                 listeners: {
                     move(event) {
                         const target = event.target;
                         const x = (parseFloat(target.getAttribute('data-x')) || 0) + event.dx;
                         const y = (parseFloat(target.getAttribute('data-y')) || 0) + event.dy;
+
+                        // Ensure the text cannot be dragged outside the image frame
+                        const parentRect = target.parentElement.getBoundingClientRect();
+                        const targetRect = target.getBoundingClientRect();
+
+                        if (targetRect.left + event.dx < parentRect.left) {
+                            event.dx = parentRect.left - targetRect.left;
+                        }
+                        if (targetRect.top + event.dy < parentRect.top) {
+                            event.dy = parentRect.top - targetRect.top;
+                        }
+                        if (targetRect.right + event.dx > parentRect.right) {
+                            event.dx = parentRect.right - targetRect.right;
+                        }
+                        if (targetRect.bottom + event.dy > parentRect.bottom) {
+                            event.dy = parentRect.bottom - targetRect.bottom;
+                        }
 
                         target.style.transform = `translate(${x}px, ${y}px)`;
                         target.setAttribute('data-x', x);

--- a/test_ui.py
+++ b/test_ui.py
@@ -56,6 +56,14 @@ def test_ui(browser):
         new_box = headline.bounding_box()
         assert new_box['x'] != box['x'] or new_box['y'] != box['y']  # Ensure the position has changed
 
+        # Ensure the text cannot be dragged outside the image frame
+        container_box = headline.evaluate('el => { const rect = el.parentElement.getBoundingClientRect(); return { left: rect.left, top: rect.top, right: rect.right, bottom: rect.bottom }; }')
+        print(f"Container Box: {container_box}, New Box: {new_box}")  # Debugging information
+        assert container_box['left'] <= new_box['x']
+        assert container_box['top'] <= new_box['y']
+        assert container_box['right'] >= new_box['x'] + new_box['width']
+        assert container_box['bottom'] >= new_box['y'] + new_box['height']
+
 
 def test_ui_with_limited_images(browser):
     page = browser.new_page()
@@ -103,3 +111,11 @@ def test_ui_with_limited_images(browser):
         page.mouse.up()
         new_box = headline.bounding_box()
         assert new_box['x'] != box['x'] or new_box['y'] != box['y']  # Ensure the position has changed
+
+        # Ensure the text cannot be dragged outside the image frame
+        container_box = headline.evaluate('el => { const rect = el.parentElement.getBoundingClientRect(); return { left: rect.left, top: rect.top, right: rect.right, bottom: rect.bottom }; }')
+        print(f"Container Box: {container_box}, New Box: {new_box}")  # Debugging information
+        assert container_box['left'] <= new_box['x']
+        assert container_box['top'] <= new_box['y']
+        assert container_box['right'] >= new_box['x'] + new_box['width']
+        assert container_box['bottom'] >= new_box['y'] + new_box['height']


### PR DESCRIPTION
This PR addresses the requirement to ensure that the draggable text elements cannot be moved outside the boundaries of their respective image frames. The following changes were made:

1. Updated `scripts.js` to include boundary constraints using `interact.js`.
2. Updated Playwright tests to ensure the text cannot be dragged outside the image frame.

### Test Plan

pytest / playwright