### PR TITLE
TES-17: Ensure text can't leave image frame

### DIFF
--- a/templates/static/scripts.js
+++ b/templates/static/scripts.js
@@ -31,10 +31,13 @@ document.getElementById('url-form').addEventListener('submit', async function(ev
             // Initialize interact.js for drag-and-drop
             interact('.draggable').draggable({
                 modifiers: [
-                    interact.modifiers.restrict({
-                        restriction: 'parent',
-                        endOnly: true,
-                        elementRect: { top: 0, left: 0, bottom: 1, right: 1 }
+                    interact.modifiers.restrictEdges({
+                        outer: 'parent',
+                        endOnly: true
+                    }),
+                    interact.modifiers.restrictSize({
+                        min: { width: 100, height: 50 },
+                        max: { width: 300, height: 150 }
                     })
                 ],
                 listeners: {
@@ -42,23 +45,6 @@ document.getElementById('url-form').addEventListener('submit', async function(ev
                         const target = event.target;
                         const x = (parseFloat(target.getAttribute('data-x')) || 0) + event.dx;
                         const y = (parseFloat(target.getAttribute('data-y')) || 0) + event.dy;
-
-                        // Ensure the text cannot be dragged outside the image frame
-                        const parentRect = target.parentElement.getBoundingClientRect();
-                        const targetRect = target.getBoundingClientRect();
-
-                        if (targetRect.left + event.dx < parentRect.left) {
-                            event.dx = parentRect.left - targetRect.left;
-                        }
-                        if (targetRect.top + event.dy < parentRect.top) {
-                            event.dy = parentRect.top - targetRect.top;
-                        }
-                        if (targetRect.right + event.dx > parentRect.right) {
-                            event.dx = parentRect.right - targetRect.right;
-                        }
-                        if (targetRect.bottom + event.dy > parentRect.bottom) {
-                            event.dy = parentRect.bottom - targetRect.bottom;
-                        }
 
                         target.style.transform = `translate(${x}px, ${y}px)`;
                         target.setAttribute('data-x', x);

--- a/templates/static/scripts.js
+++ b/templates/static/scripts.js
@@ -30,11 +30,35 @@ document.getElementById('url-form').addEventListener('submit', async function(ev
 
             // Initialize interact.js for drag-and-drop
             interact('.draggable').draggable({
+                modifiers: [
+                    interact.modifiers.restrict({
+                        restriction: 'parent',
+                        endOnly: true,
+                        elementRect: { top: 0, left: 0, bottom: 1, right: 1 }
+                    })
+                ],
                 listeners: {
                     move(event) {
                         const target = event.target;
                         const x = (parseFloat(target.getAttribute('data-x')) || 0) + event.dx;
                         const y = (parseFloat(target.getAttribute('data-y')) || 0) + event.dy;
+
+                        // Ensure the text cannot be dragged outside the image frame
+                        const parentRect = target.parentElement.getBoundingClientRect();
+                        const targetRect = target.getBoundingClientRect();
+
+                        if (targetRect.left + event.dx < parentRect.left) {
+                            event.dx = parentRect.left - targetRect.left;
+                        }
+                        if (targetRect.top + event.dy < parentRect.top) {
+                            event.dy = parentRect.top - targetRect.top;
+                        }
+                        if (targetRect.right + event.dx > parentRect.right) {
+                            event.dx = parentRect.right - targetRect.right;
+                        }
+                        if (targetRect.bottom + event.dy > parentRect.bottom) {
+                            event.dy = parentRect.bottom - targetRect.bottom;
+                        }
 
                         target.style.transform = `translate(${x}px, ${y}px)`;
                         target.setAttribute('data-x', x);

--- a/test_ui.py
+++ b/test_ui.py
@@ -56,6 +56,13 @@ def test_ui(browser):
         new_box = headline.bounding_box()
         assert new_box['x'] != box['x'] or new_box['y'] != box['y']  # Ensure the position has changed
 
+        # Ensure the text cannot be dragged outside the image frame
+        container_box = headline.evaluate('el => el.parentElement.getBoundingClientRect()')
+        assert container_box['left'] <= new_box['x']
+        assert container_box['top'] <= new_box['y']
+        assert container_box['right'] >= new_box['x'] + new_box['width']
+        assert container_box['bottom'] >= new_box['y'] + new_box['height']
+
 
 def test_ui_with_limited_images(browser):
     page = browser.new_page()
@@ -103,3 +110,10 @@ def test_ui_with_limited_images(browser):
         page.mouse.up()
         new_box = headline.bounding_box()
         assert new_box['x'] != box['x'] or new_box['y'] != box['y']  # Ensure the position has changed
+
+        # Ensure the text cannot be dragged outside the image frame
+        container_box = headline.evaluate('el => el.parentElement.getBoundingClientRect()')
+        assert container_box['left'] <= new_box['x']
+        assert container_box['top'] <= new_box['y']
+        assert container_box['right'] >= new_box['x'] + new_box['width']
+        assert container_box['bottom'] >= new_box['y'] + new_box['height']


### PR DESCRIPTION
This PR updates the `interact.js` configuration to ensure that the draggable text elements cannot be moved outside the boundaries of their respective image frames. It also includes updated tests to verify this behavior.

### Test Plan

pytest / playwright