### PR TITLE
Improve text quality for downloaded images

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -71,7 +71,11 @@ def download_image(request: DownloadImageRequest):
 
     image = Image.open(BytesIO(response.content))
     draw = ImageDraw.Draw(image)
-    font = ImageFont.load_default()  # You can specify a custom font here
+    
+    # Load a TrueType font
+    font_path = "app/static/fonts/Arial.ttf"
+    font_size = 20  # Adjust the font size as needed
+    font = ImageFont.truetype(font_path, font_size)
 
     draw.text((request.x, request.y), request.text, font=font, fill="black")
 


### PR DESCRIPTION
Improved the quality of the text overlayed on the downloaded image by using a TrueType font (Arial.ttf). Updated the `download_image` endpoint to use the TTF font with a suitable size and anti-aliasing. Ensured the existing tests still pass.

### Test Plan

pytest / playwright