### PR TITLE
Fix CORS issues for image cropping by proxying image requests through backend

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -88,3 +88,17 @@ def download_image(request: DownloadImageRequest):
     img_byte_arr.seek(0)
 
     return StreamingResponse(img_byte_arr, media_type="image/png", headers={"Content-Disposition": "attachment; filename=overlayed_image.png"})
+
+@app.get("/fetch-image")
+def fetch_image(url: HttpUrl):
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3",
+        "Accept": "*/*",
+    }
+    try:
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()
+    except requests.RequestException as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    return StreamingResponse(BytesIO(response.content), media_type=response.headers['Content-Type'])

--- a/templates/static/scripts.js
+++ b/templates/static/scripts.js
@@ -19,7 +19,7 @@ document.getElementById('url-form').addEventListener('submit', async function(ev
                 container.classList.add('image-container');
 
                 const img = document.createElement('img');
-                img.src = src;
+                img.src = `/fetch-image?url=${encodeURIComponent(src)}`;
                 img.alt = 'Extracted image';
                 img.style.maxWidth = '100%';
                 container.appendChild(img);
@@ -34,7 +34,7 @@ document.getElementById('url-form').addEventListener('submit', async function(ev
                 const cropButton = document.createElement('button');
                 cropButton.textContent = 'Crop';
                 cropButton.addEventListener('click', () => {
-                    cropImage.src = src;
+                    cropImage.src = `/fetch-image?url=${encodeURIComponent(src)}`;
                     cropContainer.style.display = 'block';
                     cropper = new Cropper(cropImage, {
                         aspectRatio: 16 / 9,

--- a/tests/test_fetch_image.py
+++ b/tests/test_fetch_image.py
@@ -1,0 +1,22 @@
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch, MagicMock
+from app.main import app
+from io import BytesIO
+
+client = TestClient(app)
+
+def mock_requests_get(*args, **kwargs):
+    img_byte_arr = BytesIO(b"fake image content")
+    response = MagicMock()
+    response.content = img_byte_arr.read()
+    response.status_code = 200
+    response.headers = {'Content-Type': 'image/png'}
+    return response
+
+@patch('requests.get', side_effect=mock_requests_get)
+def test_fetch_image(mock_get):
+    response = client.get("/fetch-image", params={"url": "http://example.com/image.png"})
+    assert response.status_code == 200
+    assert response.headers["Content-Type"] == "image/png"
+    assert response.content == b"fake image content"


### PR DESCRIPTION
This PR addresses the CORS issues encountered when attempting to crop images by implementing a backend proxy for image requests. The changes include:

1. **Backend Endpoint**: Added a new endpoint in `app/routes.py` to fetch and serve images from external URLs, bypassing CORS restrictions.
2. **Frontend Update**: Modified `templates/static/scripts.js` to request images from the new backend endpoint instead of directly from the external URL.
3. **Testing**: Added a new test file `tests/test_fetch_image.py` to ensure the new backend endpoint correctly fetches and serves images.

### Test Plan

pytest / playwright