### PR TITLE
Fix cropping functionality to display cropped image

### DIFF
--- a/templates/static/scripts.js
+++ b/templates/static/scripts.js
@@ -6,6 +6,7 @@ document.getElementById('url-form').addEventListener('submit', async function(ev
     const cropImage = document.getElementById('crop-image');
     const cropButton = document.getElementById('crop-button');
     let cropper;
+    let currentImageContainer; // To keep track of the current image container being cropped
 
     imageResultDiv.innerHTML = ''; // Clear previous images
 
@@ -40,6 +41,7 @@ document.getElementById('url-form').addEventListener('submit', async function(ev
                         aspectRatio: 16 / 9,
                         viewMode: 1,
                     });
+                    currentImageContainer = container; // Set the current image container
                 });
                 container.appendChild(cropButton);
 
@@ -92,10 +94,9 @@ document.getElementById('url-form').addEventListener('submit', async function(ev
         croppedImage.alt = 'Cropped image';
         croppedImage.style.maxWidth = '100%';
 
-        // Replace the original image with the cropped image
-        const originalImageContainer = cropContainer.previousElementSibling;
-        originalImageContainer.innerHTML = '';
-        originalImageContainer.appendChild(croppedImage);
+        // Replace the original image with the cropped image in the current image container
+        const originalImage = currentImageContainer.querySelector('img');
+        originalImage.src = croppedImageURL;
 
         cropContainer.style.display = 'none';
         cropper.destroy();

--- a/templates/static/scripts.js
+++ b/templates/static/scripts.js
@@ -85,7 +85,18 @@ document.getElementById('url-form').addEventListener('submit', async function(ev
     cropButton.addEventListener('click', () => {
         const croppedCanvas = cropper.getCroppedCanvas();
         const croppedImageURL = croppedCanvas.toDataURL('image/png');
-        cropImage.src = croppedImageURL;
+        
+        // Display the cropped image
+        const croppedImage = document.createElement('img');
+        croppedImage.src = croppedImageURL;
+        croppedImage.alt = 'Cropped image';
+        croppedImage.style.maxWidth = '100%';
+
+        // Replace the original image with the cropped image
+        const originalImageContainer = cropContainer.previousElementSibling;
+        originalImageContainer.innerHTML = '';
+        originalImageContainer.appendChild(croppedImage);
+
         cropContainer.style.display = 'none';
         cropper.destroy();
     });

--- a/templates/static/scripts.js
+++ b/templates/static/scripts.js
@@ -49,7 +49,8 @@ document.getElementById('url-form').addEventListener('submit', async function(ev
                 downloadButton.textContent = 'Download';
                 downloadButton.addEventListener('click', () => {
                     headline.style.pointerEvents = 'none'; // Disable pointer events on the headline
-                    downloadImage(src, data.headlines[index], headline);
+                    const imageElement = container.querySelector('img');
+                    downloadImage(imageElement.src, data.headlines[index], headline);
                 });
                 container.appendChild(downloadButton);
 

--- a/tests/test_ui/test_ui_crop_image.py
+++ b/tests/test_ui/test_ui_crop_image.py
@@ -29,7 +29,7 @@ def test_ui_crop_image(browser):
     page.click("#crop-button")
 
     # Verify the cropped image
-    crop_image = page.query_selector("#crop-image")
+    crop_image = page.query_selector("#image-result .image-container img")
     assert crop_image is not None
 
     page.close()

--- a/tests/test_ui/test_ui_crop_image.py
+++ b/tests/test_ui/test_ui_crop_image.py
@@ -1,4 +1,6 @@
 import pytest
+from io import BytesIO
+from PIL import Image
 
 def test_ui_crop_image(browser):
     page = browser.new_page()
@@ -9,6 +11,20 @@ def test_ui_crop_image(browser):
         content_type="application/json",
         body='{"images": ["http://example.com/image1.jpg"], "headlines": ["Mocked Ad Headline"]}'
     ))
+
+    # Mock the fetch request to /fetch-image
+    def mock_fetch_image(route):
+        img = Image.new('RGB', (800, 600), color=(73, 109, 137))
+        img_byte_arr = BytesIO()
+        img.save(img_byte_arr, format='PNG')
+        img_byte_arr.seek(0)
+        route.fulfill(
+            status=200,
+            content_type="image/png",
+            body=img_byte_arr.read()
+        )
+
+    page.route("**/fetch-image?url=http%3A%2F%2Fexample.com%2Fimage1.jpg", mock_fetch_image)
 
     page.goto("http://localhost:8080/")
 
@@ -35,5 +51,33 @@ def test_ui_crop_image(browser):
     # Ensure the original images are still present
     original_images = page.query_selector_all("#image-result .image-container img")
     assert len(original_images) == 1  # Ensure only one image is present
+
+    # Test drag-and-drop functionality on the cropped image
+    headline = page.query_selector("#image-result p.draggable")
+    box = headline.bounding_box()
+    print(f"Initial position: x={box['x']}, y={box['y']}")  # Log initial position
+    page.mouse.move(box['x'] + box['width'] / 2, box['y'] + box['height'] / 2)
+    page.mouse.down()
+    page.mouse.move(box['x'] + 100, box['y'] + 100)
+    page.mouse.up()
+    new_box = headline.bounding_box()
+    print(f"New position: x={new_box['x']}, y={new_box['y']}")  # Log new position
+    assert new_box['x'] != box['x'] or new_box['y'] != box['y']  # Ensure the position has changed
+
+    # Mock the download request
+    page.route("**/download-image", lambda route: route.fulfill(
+        status=200,
+        content_type="image/png",
+        headers={"Content-Disposition": "attachment; filename=overlayed_image.png"},
+        body=b""
+    ))
+
+    # Click the download button for the cropped image
+    with page.expect_download() as download_info:
+        page.click("#image-result .image-container button:nth-of-type(2)")  # Ensure the correct button is clicked
+    download = download_info.value
+
+    # Verify the download
+    assert download.suggested_filename == "overlayed_image.png"
 
     page.close()

--- a/tests/test_ui/test_ui_crop_image.py
+++ b/tests/test_ui/test_ui_crop_image.py
@@ -32,4 +32,8 @@ def test_ui_crop_image(browser):
     crop_image = page.query_selector("#image-result .image-container img")
     assert crop_image is not None
 
+    # Ensure the original images are still present
+    original_images = page.query_selector_all("#image-result .image-container img")
+    assert len(original_images) == 1  # Ensure only one image is present
+
     page.close()


### PR DESCRIPTION
### Summary

- Updated the event listener for the crop button to display the cropped image.
- Added an end-to-end test to verify the cropping functionality.

### Details

1. **Updated the Event Listener**:
   - Modified the event listener for the crop button in `templates/static/scripts.js` to handle the display of the cropped image.
   - Ensured the cropped image replaces the original image in the UI.

2. **End-to-End Test**:
   - Added a Playwright test in `tests/test_ui/test_ui_crop_image.py` to simulate the user interaction of cropping an image and verifying the result.

This PR addresses the issue where the cropped image was not being displayed after clicking the second crop button.

### Test Plan

pytest / playwright