### PR TITLE
Enable Text Editing for Overlayed Text

### DIFF
--- a/templates/static/scripts.js
+++ b/templates/static/scripts.js
@@ -30,6 +30,7 @@ document.getElementById('url-form').addEventListener('submit', async function(ev
                 headline.classList.add('draggable');
                 headline.setAttribute('data-x', 10); // Set initial x position
                 headline.setAttribute('data-y', 10); // Set initial y position
+                headline.setAttribute('contenteditable', 'true'); // Make the text editable
                 container.appendChild(headline);
 
                 const cropButton = document.createElement('button');
@@ -50,11 +51,15 @@ document.getElementById('url-form').addEventListener('submit', async function(ev
                 downloadButton.addEventListener('click', () => {
                     headline.style.pointerEvents = 'none'; // Disable pointer events on the headline
                     const imageElement = container.querySelector('img');
-                    downloadImage(imageElement, data.headlines[index], headline);
+                    downloadImage(imageElement, headline.textContent, headline);
                 });
                 container.appendChild(downloadButton);
 
                 imageResultDiv.appendChild(container);
+
+                // Add logging to check positions and dimensions
+                console.log("Headline position and dimensions:", headline.getBoundingClientRect());
+                console.log("Download button position and dimensions:", downloadButton.getBoundingClientRect());
             });
 
             // Initialize interact.js for drag-and-drop

--- a/templates/static/styles.css
+++ b/templates/static/styles.css
@@ -68,10 +68,16 @@ button:hover {
     border-radius: 3px;
 }
 
+.draggable[contenteditable="true"] {
+    border: 1px dashed #ccc;
+    padding: 5px;
+}
+
 .image-container button {
     margin-top: 10px;
     z-index: 1; /* Ensure the button is above the draggable element */
     position: relative; /* Ensure the button is positioned correctly */
+    display: block; /* Ensure buttons are displayed in a block format to avoid overlap */
 }
 
 #crop-container {

--- a/tests/test_ui/test_ui_text_editing.py
+++ b/tests/test_ui/test_ui_text_editing.py
@@ -1,0 +1,36 @@
+import pytest
+
+def test_ui_text_editing(browser):
+    page = browser.new_page()
+
+    # Mock the fetch request to /extract-text
+    page.route("**/extract-text?url=http%3A%2F%2Fexample.com", lambda route: route.fulfill(
+        status=200,
+        content_type="application/json",
+        body='{"images": ["http://example.com/image1.jpg"], "headlines": ["Mocked Ad Headline"]}'
+    ))
+
+    page.goto("http://localhost:8080/")
+
+    # Test form submission
+    page.fill("input[name='url']", "http://example.com")
+    page.click("button[type='submit']")
+
+    # Wait for the result to be updated
+    page.wait_for_selector("#image-result .image-container")
+
+    # Add a small delay to ensure all elements are rendered and positioned
+    page.wait_for_timeout(1000)
+
+    # Edit the text
+    headline = page.query_selector("#image-result p.draggable")
+    headline.click()
+    page.keyboard.press("Control+A")
+    page.keyboard.type("Edited Headline")
+    page.keyboard.press("Enter")
+
+    # Verify the edited text
+    edited_text = headline.text_content()
+    assert edited_text == "Edited Headline"
+
+    page.close()


### PR DESCRIPTION
Enable text editing for overlayed text on images. Users can now click on the text to edit it directly in the UI. The edited text is saved and used during the download process.

### Test Plan

pytest / playwright