### PR TITLE
Remove background from overlayed text

### DIFF
--- a/templates/static/scripts.js
+++ b/templates/static/scripts.js
@@ -31,6 +31,7 @@ document.getElementById('url-form').addEventListener('submit', async function(ev
                 headline.setAttribute('data-x', 10); // Set initial x position
                 headline.setAttribute('data-y', 10); // Set initial y position
                 headline.setAttribute('contenteditable', 'true'); // Make the text editable
+                headline.style.backgroundColor = 'transparent'; // Ensure no background
                 container.appendChild(headline);
 
                 const fontSizeLabel = document.createElement('label');

--- a/templates/static/styles.css
+++ b/templates/static/styles.css
@@ -65,7 +65,7 @@ button:hover {
     padding: 5px;
     border: 1px solid #ccc;
     border-radius: 3px;
-    background-color: transparent; /* Ensure no background */
+    background-color: transparent !important; /* Ensure no background */
 }
 
 .draggable[contenteditable="true"] {

--- a/templates/static/styles.css
+++ b/templates/static/styles.css
@@ -63,9 +63,9 @@ button:hover {
     cursor: move;
     user-select: none;
     padding: 5px;
-    background-color: rgba(255, 255, 255, 0.7);
     border: 1px solid #ccc;
     border-radius: 3px;
+    background-color: transparent; /* Ensure no background */
 }
 
 .draggable[contenteditable="true"] {

--- a/tests/test_ui/test_ui_text_background.py
+++ b/tests/test_ui/test_ui_text_background.py
@@ -1,0 +1,29 @@
+import pytest
+
+def test_ui_text_background(browser):
+    page = browser.new_page()
+
+    # Mock the fetch request to /extract-text
+    page.route("**/extract-text?url=http%3A%2F%2Fexample.com", lambda route: route.fulfill(
+        status=200,
+        content_type="application/json",
+        body='{"images": ["http://example.com/image1.jpg"], "headlines": ["Mocked Ad Headline"]}'
+    ))
+
+    page.goto("http://localhost:8080/")
+
+    # Test form submission
+    page.fill("input[name='url']", "http://example.com")
+    page.click("button[type='submit']")
+
+    # Wait for the result to be updated
+    page.wait_for_selector("#image-result .image-container")
+
+    # Verify the absence of background color
+    headline = page.query_selector("#image-result p.draggable")
+    background_color = page.evaluate('''(headline) => {
+        return window.getComputedStyle(headline).backgroundColor;
+    }''', headline)
+    assert background_color == "rgba(0, 0, 0, 0)"  # Transparent background
+
+    page.close()


### PR DESCRIPTION
This PR addresses the issue of the overlayed text rendering a background. The background was removed by updating the CSS styles for the `.draggable` class. A new Playwright test was added to verify the absence of the background color.

### Test Plan

pytest / playwright