### PR TITLE
Remove padding from overlayed text

### DIFF
--- a/templates/static/styles.css
+++ b/templates/static/styles.css
@@ -62,10 +62,10 @@ button:hover {
     left: 10px; /* Adjust as needed */
     cursor: move;
     user-select: none;
-    padding: 5px;
     border: 1px solid #ccc;
     border-radius: 3px;
     background-color: transparent !important; /* Ensure no background */
+    padding: 0 !important; /* Remove padding */
 }
 
 .draggable[contenteditable="true"] {

--- a/tests/test_ui/test_ui_text_padding.py
+++ b/tests/test_ui/test_ui_text_padding.py
@@ -1,0 +1,33 @@
+import pytest
+
+def test_ui_text_padding(browser):
+    page = browser.new_page()
+
+    # Mock the fetch request to /extract-text
+    page.route("**/extract-text?url=http%3A%2F%2Fexample.com", lambda route: route.fulfill(
+        status=200,
+        content_type="application/json",
+        body='{"images": ["http://example.com/image1.jpg"], "headlines": ["Mocked Ad Headline"]}'
+    ))
+
+    page.goto("http://localhost:8080/")
+
+    # Test form submission
+    page.fill("input[name='url']", "http://example.com")
+    page.click("button[type='submit']")
+
+    # Wait for the result to be updated
+    page.wait_for_selector("#image-result .image-container")
+
+    # Verify the absence of padding
+    headline = page.query_selector("#image-result p.draggable")
+    padding = page.evaluate('''(headline) => {
+        return window.getComputedStyle(headline).padding;
+    }''', headline)
+    
+    # Log the padding value for debugging
+    print(f"Computed padding: {padding}")
+    
+    assert padding == "0px"  # Ensure no padding
+
+    page.close()


### PR DESCRIPTION
This PR addresses the issue of padding in the overlayed text. The padding has been removed to ensure that the text appears without any extra space around it. The following changes were made:

1. Updated the CSS to remove padding from the `.draggable` class.
2. Added a test to verify that the padding has been removed from the overlayed text.

All functionalities such as drag-and-drop, text editing, and downloading remain intact.

### Test Plan

pytest / playwright