### PR TITLE
Update downloaded image filename to match ad headline

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -74,6 +74,7 @@ async def download_image(
     font_size: int = Form(20),  # Default value
     color: str = Form(...),
     font_type: str = Form(...),
+    headline: str = Form(...)  # Add headline parameter
 ):
     try:
         image_data = await image.read()
@@ -105,7 +106,14 @@ async def download_image(
     image.save(img_byte_arr, format='PNG')
     img_byte_arr.seek(0)
 
-    return StreamingResponse(img_byte_arr, media_type="image/png", headers={"Content-Disposition": "attachment; filename=overlayed_image.png"})
+    # Sanitize the headline to create a valid filename
+    sanitized_headline = "".join([c if c.isalnum() else "_" for c in headline])
+
+    return StreamingResponse(
+        img_byte_arr, 
+        media_type="image/png", 
+        headers={"Content-Disposition": f"attachment; filename={sanitized_headline}.png"}
+    )
 
 @app.get("/fetch-image")
 def fetch_image(url: HttpUrl):

--- a/app/templates/static/image_manipulation.js
+++ b/app/templates/static/image_manipulation.js
@@ -2,10 +2,12 @@ async function downloadImage(imageElement, text, headlineElement, fontSize, colo
     const x = parseFloat(headlineElement.getAttribute('data-x')) || 0;
     const y = parseFloat(headlineElement.getAttribute('data-y')) || 0;
     const imageUrl = imageElement.dataset.blob || imageElement.src;
+    const headline = headlineElement.textContent.trim();  // Get the headline text
 
     // Log the coordinates and dimensions
     console.log(`Text: ${text}, X: ${x}, Y: ${y}, Font Size: ${fontSize}, Color: ${color}, Font Type: ${fontType}`);
     console.log(`Image URL: ${imageUrl}`);
+    console.log(`Headline: ${headline}`);
     console.log(`Headline dimensions: ${headlineElement.getBoundingClientRect()}`);
     console.log(`Image dimensions: ${imageElement.getBoundingClientRect()}`);
     console.log(`Image size: Width: ${imageElement.naturalWidth}, Height: ${imageElement.naturalHeight}`);
@@ -21,6 +23,7 @@ async function downloadImage(imageElement, text, headlineElement, fontSize, colo
     formData.append('font_size', fontSize); // Include the font size
     formData.append('color', color); // Include the color
     formData.append('font_type', fontType); // Include the font type
+    formData.append('headline', headline); // Include the headline
 
     const downloadResponse = await fetch('/download-image', {
         method: 'POST',
@@ -33,7 +36,7 @@ async function downloadImage(imageElement, text, headlineElement, fontSize, colo
         const a = document.createElement('a');
         a.style.display = 'none';
         a.href = url;
-        a.download = 'overlayed_image.png';
+        a.download = `${headline}.png`;  // Use the headline as the filename
         document.body.appendChild(a);
         a.click();
         window.URL.revokeObjectURL(url);

--- a/tests/test_download_image.py
+++ b/tests/test_download_image.py
@@ -28,11 +28,19 @@ def test_download_image(mock_get):
     img_byte_arr.seek(0)
 
     files = {'image': ('image.png', img_byte_arr, 'image/png')}
-    data = {'text': 'Test', 'x': 10, 'y': 10, 'font_size': 20, 'color': '#FF0000', 'font_type': 'Arial'}  # Include font type in the data
+    data = {
+        'text': 'Test', 
+        'x': 10, 
+        'y': 10, 
+        'font_size': 20, 
+        'color': '#FF0000', 
+        'font_type': 'Arial',
+        'headline': 'Test_Headline'  # Include headline in the data
+    }
 
     response = client.post("/download-image", files=files, data=data)
     assert response.status_code == 200
-    assert response.headers["Content-Disposition"] == "attachment; filename=overlayed_image.png"
+    assert response.headers["Content-Disposition"] == "attachment; filename=Test_Headline.png"
     assert response.headers["Content-Type"] == "image/png"
 
     # Verify the image content


### PR DESCRIPTION
This PR updates the functionality to ensure that the downloaded image filename matches the ad headline. Changes include:

1. Backend: Modified the `/download-image` endpoint to accept the headline and use it as the filename.
2. Frontend: Updated the `downloadImage` function to include the headline in the form data.
3. Testing: Updated the test cases to verify that the downloaded image filename matches the headline.

### Test Plan

pytest / playwright